### PR TITLE
Fix offset write to mdl

### DIFF
--- a/ConfigWindow.cs
+++ b/ConfigWindow.cs
@@ -499,7 +499,7 @@ public class ConfigWindow : Window {
                     try {
                         _fileDialogManager.SaveFileDialog("Save MDL File...", "MDL File{.mdl}", "output.mdl", ".mdl", (b, files) => {
                             attributes.RemoveAll(a => a.StartsWith("heels_offset="));
-                            attributes.Add($"heels_offset={mdlEditorOffset}");
+                            attributes.Add($"heels_offset={mdlEditorOffset.ToString(CultureInfo.InvariantCulture)}");
                             loadedFile.Attributes = attributes.ToArray();
                             var outputBytes = loadedFile.Write();
                             File.WriteAllBytes(files, outputBytes);


### PR DESCRIPTION
This will fix the format the float is written to the mdl file.
Unfortunately every file, which has the wrong format (0,03 instead of 0.03) has to be redone.