### PR TITLE
Make string equality OrdinalIgnoreCase

### DIFF
--- a/CharacterConfig.cs
+++ b/CharacterConfig.cs
@@ -132,13 +132,13 @@ public class CharacterConfig : IOffsetProvider {
             switch (hc.Slot) {
                 case ModelSlot.Feet:
                     feetModelPath ??= Plugin.GetModelPath(human, ModelSlot.Feet);
-                    return (hc.PathMode == false && hc.ModelId == human->Feet.Id) || (hc.PathMode && feetModelPath != null && feetModelPath.Equals(hc.Path));
+                    return (hc.PathMode == false && hc.ModelId == human->Feet.Id) || (hc.PathMode && feetModelPath != null && feetModelPath.Equals(hc.Path, StringComparison.OrdinalIgnoreCase));
                 case ModelSlot.Top:
                     topModelPath ??= Plugin.GetModelPath(human, ModelSlot.Top);
-                    return (hc.PathMode == false && hc.ModelId == human->Top.Id) || (hc.PathMode && topModelPath != null && topModelPath.Equals(hc.Path));
+                    return (hc.PathMode == false && hc.ModelId == human->Top.Id) || (hc.PathMode && topModelPath != null && topModelPath.Equals(hc.Path, StringComparison.OrdinalIgnoreCase));
                 case ModelSlot.Legs:
                     legsModelPath ??= Plugin.GetModelPath(human, ModelSlot.Legs);
-                    return (hc.PathMode == false && hc.ModelId == human->Legs.Id) || (hc.PathMode && legsModelPath != null && legsModelPath.Equals(hc.Path));
+                    return (hc.PathMode == false && hc.ModelId == human->Legs.Id) || (hc.PathMode && legsModelPath != null && legsModelPath.Equals(hc.Path, StringComparison.OrdinalIgnoreCase));
                 default:
                     return false;
             }
@@ -163,7 +163,7 @@ public class CharacterConfig : IOffsetProvider {
             if (h.Slot != hc.Slot) continue;
 
             if (h.PathMode) {
-                if (h.Path != hc.Path) continue;
+                if (!string.Equals(h.Path, hc.Path, StringComparison.OrdinalIgnoreCase)) continue;
             } else {
                 if (h.ModelId != hc.ModelId) continue;
             }

--- a/ConfigWindow.cs
+++ b/ConfigWindow.cs
@@ -1327,7 +1327,7 @@ public class ConfigWindow : Window {
                         }
 
                         if (ImGui.Button($"Add Path: {pathDisplay}")) {
-                            characterConfig.HeelsConfig.Add(new HeelConfig() { PathMode = true, Path = path, Slot = slot, Enabled = !characterConfig.HeelsConfig.Any(h => h is { PathMode: true } && h.Path == path) });
+                            characterConfig.HeelsConfig.Add(new HeelConfig() { PathMode = true, Path = path, Slot = slot, Enabled = !characterConfig.HeelsConfig.Any(h => h is { PathMode: true } && string.Equals(h.Path, path, StringComparison.OrdinalIgnoreCase)) });
                         }
 
                         if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled)) {


### PR DESCRIPTION
This matches the pattern in ConfigWindow.cs:1254 and will resolve the case that existing migrated configurations will generally be in all lowercase

Example of old migrated config: \
![image](https://github.com/user-attachments/assets/b6918a44-8140-405f-b102-6fde83bc2842)
