### PR TITLE
Rename character config command implementation

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -93,7 +93,7 @@ public unsafe class Plugin : IDalamudPlugin {
         PluginService.Commands.AddHandler("/heels", new CommandInfo(OnCommand) 
         { 
             HelpMessage = $"Open the {Name} config window.\n" +
-            "/heels renameChar \"<source char name>|<source world>\" \"<target char name>|<target world>\" → Rename existing character config to new character config", ShowInHelp = true 
+            "/heels renamechar \"<source char name>|<source world>\" \"<target char name>|<target world>\" → Rename existing character config to new character config", ShowInHelp = true 
         });
         
         ApiProvider.Init(this);
@@ -552,7 +552,7 @@ public unsafe class Plugin : IDalamudPlugin {
         if (splitArgs.Count > 0)
         {
 
-            switch (splitArgs[0])
+            switch (splitArgs[0].ToLowerInvariant())
             {
                 case "debug":
                     IsDebug = !IsDebug;
@@ -575,7 +575,7 @@ public unsafe class Plugin : IDalamudPlugin {
                 case "temp":
                     Config.TempOffsetWindowOpen = !Config.TempOffsetWindowOpen;
                     break;
-                case "renameChar":
+                case "renamechar":
                     if (splitArgs.Count != 3)
                     {
                         break;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using Dalamud.Configuration;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.Command;
@@ -22,9 +21,6 @@ using Dalamud.Utility.Signatures;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
-using FFXIVClientStructs.FFXIV.Client.UI;
-using Lumina;
-using Lumina.Excel.GeneratedSheets2;
 using World = Lumina.Excel.GeneratedSheets2.World;
 
 namespace SimpleHeels;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -90,8 +90,7 @@ public unsafe class Plugin : IDalamudPlugin {
         pluginInterface.UiBuilder.Draw += windowSystem.Draw;
         pluginInterface.UiBuilder.OpenConfigUi += () => OnCommand(string.Empty, string.Empty);
 
-        PluginService.Commands.AddHandler("/heels", new CommandInfo(OnCommand) 
-        { 
+        PluginService.Commands.AddHandler("/heels", new CommandInfo(OnCommand) { 
             HelpMessage = $"Open the {Name} config window.\n" +
             "/heels renamechar \"<source char name>|<source world>\" \"<target char name>|<target world>\" → Rename existing character config to new character config", ShowInHelp = true 
         });
@@ -546,14 +545,13 @@ public unsafe class Plugin : IDalamudPlugin {
     }
 
     private void OnCommand(string command, string args) {
-
-        var splitArgs = Regex.Matches(args, @"[\""].+?[\""]|[^ ]+").Cast<Match>().Select(m => m.Value).ToList();
-
-        if (splitArgs.Count > 0)
-        {
-
-            switch (splitArgs[0].ToLowerInvariant())
-            {
+        var splitArgs = Regex.Matches(args, @"[\""].+?[\""]|[^ ]+")
+            .Cast<Match>()
+            .Select(m => m.Value)
+            .ToList();
+        if (splitArgs.Count > 0) {
+            switch (splitArgs[0]
+                        .ToLowerInvariant()) {
                 case "debug":
                     IsDebug = !IsDebug;
                     return;
@@ -576,44 +574,42 @@ public unsafe class Plugin : IDalamudPlugin {
                     Config.TempOffsetWindowOpen = !Config.TempOffsetWindowOpen;
                     break;
                 case "renamechar":
-                    if (splitArgs.Count != 3)
-                    {
+                    if (splitArgs.Count != 3) {
                         break;
                     }
 
-                    var sourceChar = splitArgs[1].Replace("\"", String.Empty).Split("|", StringSplitOptions.RemoveEmptyEntries);
-                    var targetChar = splitArgs[2].Replace("\"", String.Empty).Split("|", StringSplitOptions.RemoveEmptyEntries);
-
-                    if (sourceChar.Length != 2 || targetChar.Length != 2 || sourceChar.SequenceEqual(targetChar))
-                    {
+                    var sourceChar = splitArgs[1]
+                        .Replace("\"", String.Empty)
+                        .Split("|", StringSplitOptions.RemoveEmptyEntries);
+                    var targetChar = splitArgs[2]
+                        .Replace("\"", String.Empty)
+                        .Split("|", StringSplitOptions.RemoveEmptyEntries);
+                    if (sourceChar.Length != 2 || targetChar.Length != 2 || sourceChar.SequenceEqual(targetChar)) {
                         break;
                     }
 
                     var sourcename = sourceChar[0];
-                    var sourceworld = PluginService.Data.GetExcelSheet<World>()?.FirstOrDefault(w => w.Name == sourceChar[1]);
+                    var sourceworld = PluginService.Data.GetExcelSheet<World>()
+                        ?.FirstOrDefault(w => w.Name == sourceChar[1]);
                     var targetname = targetChar[0];
-                    var targetworld = PluginService.Data.GetExcelSheet<World>()?.FirstOrDefault(w => w.Name == targetChar[1]);
-
-
-                    if (targetworld == null || sourceworld == null)
-                    {
+                    var targetworld = PluginService.Data.GetExcelSheet<World>()
+                        ?.FirstOrDefault(w => w.Name == targetChar[1]);
+                    if (targetworld == null || sourceworld == null) {
                         break;
                     }
 
-
-                    var newAlreadyExists = Config.WorldCharacterDictionary.ContainsKey(targetworld.RowId) && Config.WorldCharacterDictionary[targetworld.RowId].ContainsKey(targetname);
-                    var oldAlreadyExists = Config.WorldCharacterDictionary.ContainsKey(sourceworld.RowId) && Config.WorldCharacterDictionary[sourceworld.RowId].ContainsKey(sourcename);
-
-                    if (newAlreadyExists || !oldAlreadyExists || !Config.TryAddCharacter(targetname, targetworld.RowId))
-                    {
+                    var newAlreadyExists = Config.WorldCharacterDictionary.ContainsKey(targetworld.RowId) && Config.WorldCharacterDictionary[targetworld.RowId]
+                        .ContainsKey(targetname);
+                    var oldAlreadyExists = Config.WorldCharacterDictionary.ContainsKey(sourceworld.RowId) && Config.WorldCharacterDictionary[sourceworld.RowId]
+                        .ContainsKey(sourcename);
+                    if (newAlreadyExists || !oldAlreadyExists || !Config.TryAddCharacter(targetname, targetworld.RowId)) {
                         break;
                     }
 
                     Config.WorldCharacterDictionary[targetworld.RowId][targetname] = Config.WorldCharacterDictionary[sourceworld.RowId][sourcename];
-                    Config.WorldCharacterDictionary[sourceworld.RowId].Remove(sourcename);
-
-                    if (Config.WorldCharacterDictionary[sourceworld.RowId].Count == 0)
-                    {
+                    Config.WorldCharacterDictionary[sourceworld.RowId]
+                        .Remove(sourcename);
+                    if (Config.WorldCharacterDictionary[sourceworld.RowId].Count == 0) {
                         Config.WorldCharacterDictionary.Remove(sourceworld.RowId);
                     }
 
@@ -622,10 +618,7 @@ public unsafe class Plugin : IDalamudPlugin {
                     configWindow.ToggleWithWarning();
                     break;
             }
-
-        }
-        else
-        {
+        } else {
             configWindow.ToggleWithWarning();
         }
     }


### PR DESCRIPTION
This implements a command to rename character config in similar manner as the Rename Character Config button in UI

/heels renamechar "\<old char name\>|\<old world\>" "\<new char name\>|\<new world\>"

This will be useful for people in need of config swapping between different OCs, such as for OC unique sitting offsets, as majority of the OC swapping process (Penumbra, C+, Glamourer) can already be automated via macro with commands.